### PR TITLE
s1_burst_slc: add __str__ and bbox properties

### DIFF
--- a/src/s1reader/s1_burst_slc.py
+++ b/src/s1reader/s1_burst_slc.py
@@ -172,6 +172,11 @@ class Sentinel1BurstSlc:
     burst_noise: s1_annotation.BurstNoise #Thermal noise correction
     burst_eap: s1_annotation.BurstEAP #EAP correction
 
+    def __str__(self):
+        return f"Sentinel1BurstSlc: {self.burst_id} at {self.sensing_start}"
+
+    def __repr__(self):
+        return f"{self.__class__.__name__}(burst_id={self.burst_id})"
 
     def as_isce3_radargrid(self):
         '''Init and return isce3.product.RadarGridParameters.
@@ -622,3 +627,8 @@ class Sentinel1BurstSlc:
         '''Swath name in iw1, iw2, iw3.'''
         return self.burst_id.split('_')[1]
 
+    @property
+    def bbox(self):
+        '''Returns bounding box of the burst.'''
+        # Use the provided shapely function to get the bounding box
+        return self.border[0].bounds


### PR DESCRIPTION
(Note: I'm currently pointing this at Yunjun's auto download branch, assuming that will get merged in shortly)


This adds two features to the `Sentinel1BurstSlc` class:

1. a `.bbox` method to have an easy way to see the (left, bottom, right, top) coordinates of the burst bounding box (rather than all the points given by `border`)
2. a `__str__` and `__repr__` method which doesn't print out the entire class. Since the default for `dataclass` is to show every property you define, printing one or showing on in the terminal dumps out this:


Sentinel1BurstSlc(ipf_version=<Version('3.40')>, sensing_start=datetime.datetime(2022, 1, 4, 10, 56, 38, 150515), radar_center_frequency=5405000454.33435, wavelength=0.05546576, azimuth_steer_rate=0.027757171601738514, azimuth_time_interval=0.002055556299999998, slant_range_time=0.00534849813990142, starting_range=801719.7019847372, iw2_mid_range=876523.1062693037, range_sampling_rate=64345238.12571428, range_pixel_spacing=2.329562114715323, shape=(1496, 20511), azimuth_fm_rate=Poly1d(order= 2, mean=801720, std=1.49896e+08), doppler=Doppler(poly1d=Poly1d(order= 2, mean=801915, std=1.49896e+08), lut2d=<isce3.ext.isce3.core.LUT2d object at 0x7ff63a0842f0>), range_bandwidth=56500000.0, polarization='VV', burst_id='t113_241368_iw1', platform_id='S1A', center=<shapely.geometry.point.Point object at 0x7ff63a972590>, border=[<shapely.geometry.polygon.Polygon object at 0x7ff63a9723b0>], orbit=None, orbit_direction='Descending', abs_orbit_number=41310, tiff_path='/vsizip/data/S1A_IW_SLC__1SDV_20220104T105638_20220104T105707_041310_04E928_6236.zip/S1A_IW_SLC__1SDV_20220104T105638_20220104T105707_041310_04E928_6236.SAFE/measurement/s1a-iw1-slc-vv-20220104t105638-20220104t105706-041310-04e928-004.tiff', i_burst=0, first_valid_sample=83, last_valid_sample=20510, first_valid_line=18, last_valid_line=1480, range_window_type='Hamming', range_window_coefficient=0.75, rank=9, prf_raw_data=1717.128973878037, range_chirp_rate=1078230321255.894, burst_calibration=<class 's1reader.s1_annotation.BurstCalibration'>, burst_noise=BurstNoise(range_azimith_time=datetime.datetime(2022, 1, 4, 10, 56, 38, 150515), range_line=0, range_pixel=array([    0,    40,    80,   120,   160,   200,   240,   280,   320,
         360,


(... more arrays printed out)

With this update, if you ran `bursts = load_bursts(...)` and got a list of bursts from a zip file, it would show like this:
```
Out[4]:
[Sentinel1BurstSlc(burst_id=t113_241368_iw1),
 Sentinel1BurstSlc(burst_id=t113_241369_iw1),
 Sentinel1BurstSlc(burst_id=t113_241370_iw1),
 Sentinel1BurstSlc(burst_id=t113_241371_iw1),
 ...
```